### PR TITLE
Use @types/aws-lambda for typings

### DIFF
--- a/runtime/mod.ts
+++ b/runtime/mod.ts
@@ -1,1 +1,1 @@
-export * from 'https://unpkg.com/browse/@types/aws-lambda@8.10.39/index.d.ts';
+export * from 'https://unpkg.com/@types/aws-lambda@8.10.39/index.d.ts';

--- a/runtime/mod.ts
+++ b/runtime/mod.ts
@@ -1,17 +1,1 @@
-export interface Context {
-  functionName: string;
-  functionVersion: string; // or Number?
-  invokedFunctionArn: string;
-  memoryLimitInMB: string;
-  awsRequestId: string;
-  logGroupName: string;
-  logStreamName: string;
-  identity: undefined;
-  clientContext: undefined;
-  getRemainingTimeInMillis: () => Number;
-}
-
-// In future this could be an enum with various types of Events
-export interface Event {
-  [key: string]: any;
-}
+export * from 'https://unpkg.com/browse/@types/aws-lambda@8.10.39/index.d.ts';


### PR DESCRIPTION
This gives access to all the AWS event types and responses.

The `Event` interface is gone and is replaced by different individual events like `APIGatewayProxyEvent`. There are now also results: `APIGatewayProxyResult`.