### PR TITLE
Update serverless-example's dynamodb for 1.0.0 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: denolib/setup-deno@master
         with:
-          deno-version: 0.41.0
+          deno-version: 1.0.0
       - name: start a local dynamodb
         run: |
           mkdir dyno

--- a/example-serverless/deps.ts
+++ b/example-serverless/deps.ts
@@ -2,7 +2,7 @@ export {
   createClient,
   Doc,
   DynamoDBClient
-} from "https://deno.land/x/dynamodb@v0.3.1/mod.ts";
+} from "https://deno.land/x/dynamodb@v1.0.0/mod.ts";
 
-import { v4 } from "https://deno.land/std@v0.50.0/uuid/mod.ts";
+import { v4 } from "https://deno.land/std@v0.51.0/uuid/mod.ts";
 export const uuid = v4.generate;

--- a/example-serverless/test.ts
+++ b/example-serverless/test.ts
@@ -6,7 +6,7 @@
 
 import {
   assertEquals
-} from "https://deno.land/std@v0.50.0/testing/asserts.ts";
+} from "https://deno.land/std@v0.51.0/testing/asserts.ts";
 import {
   APIGatewayProxyEvent,
   Context

--- a/example-serverless/test_util.ts
+++ b/example-serverless/test_util.ts
@@ -15,7 +15,7 @@ export async function test(t: Deno.TestDefinition) {
       throw err;
     }
   }
-  Deno.test({ name: t.name, fn: wrapped });
+  await Deno.test({ name: t.name, fn: wrapped });
 }
 
 async function setUp() {

--- a/tests/deps.ts
+++ b/tests/deps.ts
@@ -1,5 +1,5 @@
 export {
   assert,
   assertEquals
-} from "https://deno.land/std@v0.50.0/testing/asserts.ts";
-export { serve } from "https://deno.land/std@v0.50.0/http/server.ts";
+} from "https://deno.land/std@v0.51.0/testing/asserts.ts";
+export { serve } from "https://deno.land/std@v0.51.0/http/server.ts";


### PR DESCRIPTION
closes #72. 