### PR TITLE
Fix SAR publish step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,11 +44,12 @@ jobs:
           # FIXME: Installation of sam is fiddly.
           export DEBIAN_FRONTEND=noninteractive
           sudo apt -qq update &> /dev/null
-          sudo apt -qq install -y awscli python3-setuptools &> /dev/null
+          sudo apt -qq install -y awscli python3-setuptools python3-testresources &> /dev/null
           pip3 -q install -U --force pip
           export PATH=/home/runner/.local/bin:$PATH
           export SAM_CLI_TELEMETRY=1
           python3 -m pip -q install --user aws-sam-cli
+          export AWS_EC2_METADATA_DISABLED=true
           aws s3 cp --quiet deno-lambda-layer.zip s3://$DENO_LAMBDA_BUCKET/deno-lambda-layer_$DENO_LAMBDA_VERSION.zip --acl public-read
           aws s3 cp --quiet deno-lambda-example.zip s3://$DENO_LAMBDA_BUCKET/deno-lambda-example_$DENO_LAMBDA_VERSION.zip --acl public-read
           echo ---


### PR DESCRIPTION
This seems to have been broken since ubuntu-latest
upgraded to 20.04, the key step being the explicit
AWS_EC2_METADATA_DISABLED