### PR TITLE
Change bootstrap script to allow environment variables to overwrite allow all permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The following environment variables can be set to change deno-lambda's behavior:
   include `requestId` and `level` variables only (default
   `${level}\tRequestId: ${requestId}\r`).
 - `DENO_UNSTABLE` so deno runs with the `--unstable`.
+- `DENO_FLAGS_OVERRIDE` so deno only runs with a specific list of permissions. **Deno requires**: `--allow-env` and `--allow-net`
 
 Further configuration TBD.
 

--- a/runtime/bootstrap
+++ b/runtime/bootstrap
@@ -22,6 +22,11 @@ fi
 DENO_FLAGS="-A --no-check"
 DENO_CACHE_FLAGS=""
 
+DENO_FLAGS_OVERRIDE=${DENO_FLAGS_OVERRIDE-}
+if [[ ! -z "$DENO_FLAGS_OVERRIDE" ]]; then
+  DENO_FLAGS="$DENO_FLAGS $DENO_FLAGS_OVERRIDE"
+fi
+
 # For unstable flags we must pass --unstable
 DENO_UNSTABLE=${DENO_UNSTABLE-}
 if [[ ! -z "$DENO_UNSTABLE${DENO_IMPORTMAP-}" ]]; then

--- a/runtime/bootstrap
+++ b/runtime/bootstrap
@@ -24,7 +24,7 @@ DENO_CACHE_FLAGS=""
 
 DENO_FLAGS_OVERRIDE=${DENO_FLAGS_OVERRIDE-}
 if [[ ! -z "$DENO_FLAGS_OVERRIDE" ]]; then
-  DENO_FLAGS="$DENO_FLAGS $DENO_FLAGS_OVERRIDE"
+  DENO_FLAGS="$DENO_FLAGS_OVERRIDE"
 fi
 
 # For unstable flags we must pass --unstable


### PR DESCRIPTION
My colleague (@amin-RFarzin) and I were experimenting with Deno's secure runtime in Lambda (as a Lambda layer) and noticed that the bootstrap script automatically allows all permissions.

This change is to allow developers more fine-grained permission control for their Deno runtime.

Example of using this in the Lambda console:
![image](https://user-images.githubusercontent.com/65937808/135552575-651a6eda-0008-4f78-85fc-dfb87a06191a.png)

![image](https://user-images.githubusercontent.com/65937808/135552700-a8427112-f1f9-45a7-a90b-093c84317d6d.png)
