### PR TITLE
Remove version from .github/workflows

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           echo existing=${{ steps.version.outputs.existing }}
           echo latest=${{ steps.version.outputs.latest }}
-          sed -i "s/${{ steps.version.outputs.existing }}/${{ steps.version.outputs.latest }}/" tests/*.json tests/Dockerfile example-aws-cdk/cdk/example-aws-cdk-stack.ts example-serverless/serverless.yml example-sam/template.yml .github/workflows/ci.yml .github/workflows/fmt_lint.yml docker/base.dockerfile
+          sed -i "s/${{ steps.version.outputs.existing }}/${{ steps.version.outputs.latest }}/" tests/*.json tests/Dockerfile example-aws-cdk/cdk/example-aws-cdk-stack.ts example-serverless/serverless.yml example-sam/template.yml docker/base.dockerfile
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         id: cpr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: denoland/setup-deno@main
-        with:
-          deno-version: 1.16.0
       - name: start a local dynamodb
         run: |
           mkdir dyno

--- a/.github/workflows/fmt_lint.yml
+++ b/.github/workflows/fmt_lint.yml
@@ -6,8 +6,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: denoland/setup-deno@main
-        with:
-          deno-version: 1.16.0
       - name: Run fmt
         run: |
           deno fmt --check


### PR DESCRIPTION
Annoyingly the scheduled actions to update these files in a PR.
Strangely this worked the first time (it was able to update).

This is somewhat suboptimal. One workaround is to specify the
version in a file...