### PR TITLE
SAM Example: implement Makefile to run manual commands

### DIFF
--- a/example-sam/Makefile
+++ b/example-sam/Makefile
@@ -1,0 +1,6 @@
+.PHONY: build-HelloWorldFunction
+
+build-HelloWorldFunction:
+	DENO_DIR=.deno_dir deno cache hello.ts
+	cp -R ".deno_dir/gen/file/$(PWD)/" .deno_dir/LAMBDA_TASK_ROOT
+	cp -a . "$(ARTIFACTS_DIR)"

--- a/example-sam/README.md
+++ b/example-sam/README.md
@@ -6,11 +6,9 @@ An example
 ### Deploy via
 
 ```sh
-# Prior to deploy compile the application into .deno_dir.
-# (ensure you're using the same version of deno as deno-lambda.)
-DENO_DIR=.deno_dir deno cache hello.ts
-cp -R .deno_dir/gen/file/$PWD/ .deno_dir/LAMBDA_TASK_ROOT
-sam deploy --stack-name YOUR_APP_NAME --s3-bucket YOUR_BUCKET_NAME --s3-prefix YOUR_PREFIX --capabilities CAPABILITY_IAM CAPABILITY_AUTO_EXPAND
+# During the sam build phase, through the Makefile, SAM will execute the commands needed to "build" the package.
+# For still an unknown reason it is needed to run DENO_DIR=.deno_dir deno cache hello.ts command only the first time to create the .deno_dir directory
+sam build && sam deploy --stack-name YOUR_APP_NAME --s3-bucket YOUR_BUCKET_NAME --s3-prefix YOUR_PREFIX --capabilities CAPABILITY_IAM CAPABILITY_AUTO_EXPAND
 ```
 
 Note: The stack can only deploy to the same region as the s3 bucket.

--- a/example-sam/template.yml
+++ b/example-sam/template.yml
@@ -25,3 +25,5 @@ Resources:
       Events:
         ApiEvent:
           Type: HttpApi
+    Metadata: # Manage lambda build
+      BuildMethod: makefile


### PR DESCRIPTION
Hi everyone 👋🏼,

I have added the commands needed to deploy the lambda in the Makefile. The Makefile is used in the "SAM build" phase.

For still an unknown reason, it is needed to run the DENO_DIR command the first time in order to create the directory otherwise Makefile throws an error.

I will try to do more research to understand how to avoid this phase.
I have updated the cloudformation template & readme too.
